### PR TITLE
Enable Geant4 standalone test

### DIFF
--- a/scripts/g4dep.patch
+++ b/scripts/g4dep.patch
@@ -1,24 +1,25 @@
 diff --git a/examples/physics/FullCMS/Geant4/CMakeLists.txt b/examples/physics/FullCMS/Geant4/CMakeLists.txt
-index 1a927501..0b851b4c 100644
+index 1a927501..f83f3361 100644
 --- a/examples/physics/FullCMS/Geant4/CMakeLists.txt
 +++ b/examples/physics/FullCMS/Geant4/CMakeLists.txt
-@@ -13,6 +13,11 @@ find_package(Geant4 REQUIRED)
- # Setup Geant4 include directories and compile definitions
- # Setup include directory for this project
+@@ -15,6 +15,12 @@ find_package(Geant4 REQUIRED)
  #
-+get_property(TMP_INCLUDE_DIRECTORIES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
-+list(REMOVE_ITEM TMP_INCLUDE_DIRECTORIES "${VECGEOM_INCLUDE_DIR}" "${VecCore_INCLUDE_DIR}")
-+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
-+remove_definitions(-DVECGEOM_VC)
-+include_directories(${OldVc_INCLUDE_DIR})
  include(${Geant4_USE_FILE})
  include_directories(${PROJECT_SOURCE_DIR}/include)
++get_property(TMP_INCLUDE_DIRECTORIES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
++list(REMOVE_ITEM TMP_INCLUDE_DIRECTORIES "${VECGEOM_INCLUDE_DIR}" "${VecCore_INCLUDE_DIR}")
++set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
++remove_definitions(-DVECGEOM_VC)
++include_directories(${OldVc_INCLUDE_DIR})
++list(APPEND Geant4_LIBRARIES ${OldVc_INCLUDE_DIR}/../lib/libVc.a)
  
+ #----------------------------------------------------------------------------
+ # Locate sources and headers for this project
 diff --git a/examples/physics/TestEm3/Geant4/CMakeLists.txt b/examples/physics/TestEm3/Geant4/CMakeLists.txt
-index d9f9cd84..b8f5b1f1 100644
+index d9f9cd84..ac9111e4 100644
 --- a/examples/physics/TestEm3/Geant4/CMakeLists.txt
 +++ b/examples/physics/TestEm3/Geant4/CMakeLists.txt
-@@ -19,6 +19,11 @@ endif()
+@@ -19,6 +19,12 @@ endif()
  # Setup Geant4 include directories and compile definitions
  #
  include(${Geant4_USE_FILE})
@@ -27,14 +28,15 @@ index d9f9cd84..b8f5b1f1 100644
 +set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
 +remove_definitions(-DVECGEOM_VC)
 +include_directories(${OldVc_INCLUDE_DIR})
++list(APPEND Geant4_LIBRARIES ${OldVc_INCLUDE_DIR}/../lib/libVc.a)
  
  #----------------------------------------------------------------------------
  # Locate sources and headers for this project
 diff --git a/examples/physics/TestEm5/Geant4/CMakeLists.txt b/examples/physics/TestEm5/Geant4/CMakeLists.txt
-index 8195938f..bde3f3c1 100644
+index 8195938f..671cef97 100644
 --- a/examples/physics/TestEm5/Geant4/CMakeLists.txt
 +++ b/examples/physics/TestEm5/Geant4/CMakeLists.txt
-@@ -19,6 +19,11 @@ endif()
+@@ -19,6 +19,12 @@ endif()
  # Setup Geant4 include directories and compile definitions
  #
  include(${Geant4_USE_FILE})
@@ -43,6 +45,7 @@ index 8195938f..bde3f3c1 100644
 +set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
 +remove_definitions(-DVECGEOM_VC)
 +include_directories(${OldVc_INCLUDE_DIR})
++list(APPEND Geant4_LIBRARIES ${OldVc_INCLUDE_DIR}/../lib/libVc.a)
  
  #----------------------------------------------------------------------------
  # Locate sources and headers for this project

--- a/scripts/g4dep.patch
+++ b/scripts/g4dep.patch
@@ -1,0 +1,48 @@
+diff --git a/examples/physics/FullCMS/Geant4/CMakeLists.txt b/examples/physics/FullCMS/Geant4/CMakeLists.txt
+index 1a927501..0b851b4c 100644
+--- a/examples/physics/FullCMS/Geant4/CMakeLists.txt
++++ b/examples/physics/FullCMS/Geant4/CMakeLists.txt
+@@ -13,6 +13,11 @@ find_package(Geant4 REQUIRED)
+ # Setup Geant4 include directories and compile definitions
+ # Setup include directory for this project
+ #
++get_property(TMP_INCLUDE_DIRECTORIES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
++list(REMOVE_ITEM TMP_INCLUDE_DIRECTORIES "${VECGEOM_INCLUDE_DIR}" "${VecCore_INCLUDE_DIR}")
++set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
++remove_definitions(-DVECGEOM_VC)
++include_directories(${OldVc_INCLUDE_DIR})
+ include(${Geant4_USE_FILE})
+ include_directories(${PROJECT_SOURCE_DIR}/include)
+ 
+diff --git a/examples/physics/TestEm3/Geant4/CMakeLists.txt b/examples/physics/TestEm3/Geant4/CMakeLists.txt
+index d9f9cd84..b8f5b1f1 100644
+--- a/examples/physics/TestEm3/Geant4/CMakeLists.txt
++++ b/examples/physics/TestEm3/Geant4/CMakeLists.txt
+@@ -19,6 +19,11 @@ endif()
+ # Setup Geant4 include directories and compile definitions
+ #
+ include(${Geant4_USE_FILE})
++get_property(TMP_INCLUDE_DIRECTORIES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
++list(REMOVE_ITEM TMP_INCLUDE_DIRECTORIES "${VECGEOM_INCLUDE_DIR}" "${VecCore_INCLUDE_DIR}")
++set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
++remove_definitions(-DVECGEOM_VC)
++include_directories(${OldVc_INCLUDE_DIR})
+ 
+ #----------------------------------------------------------------------------
+ # Locate sources and headers for this project
+diff --git a/examples/physics/TestEm5/Geant4/CMakeLists.txt b/examples/physics/TestEm5/Geant4/CMakeLists.txt
+index 8195938f..bde3f3c1 100644
+--- a/examples/physics/TestEm5/Geant4/CMakeLists.txt
++++ b/examples/physics/TestEm5/Geant4/CMakeLists.txt
+@@ -19,6 +19,11 @@ endif()
+ # Setup Geant4 include directories and compile definitions
+ #
+ include(${Geant4_USE_FILE})
++get_property(TMP_INCLUDE_DIRECTORIES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
++list(REMOVE_ITEM TMP_INCLUDE_DIRECTORIES "${VECGEOM_INCLUDE_DIR}" "${VecCore_INCLUDE_DIR}")
++set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES ${TMP_INCLUDE_DIRECTORIES})
++remove_definitions(-DVECGEOM_VC)
++include_directories(${OldVc_INCLUDE_DIR})
+ 
+ #----------------------------------------------------------------------------
+ # Locate sources and headers for this project

--- a/scripts/install_geantv.sh
+++ b/scripts/install_geantv.sh
@@ -18,6 +18,7 @@ if ! [ -d $SOURCEDIR ]; then
 	git clone https://gitlab.cern.ch/GeantV/geant.git -b pre-beta-7
 	cd $SOURCEDIR
 	git checkout 63468c9b3b92ead35c924e8fc67c6fa13bcff493
+	git apply ${CURRDIR}/scripts/g4deps.patch
 else
 	cd $SOURCEDIR
 fi
@@ -30,10 +31,11 @@ fi
 CLHEP_LIBDIR=$(scram tool info clhep | grep "LIBDIR=" | sed 's/LIBDIR=//')
 CLHEP_INCLUDE=$(scram tool info clhep | grep "INCLUDE=" | sed 's/INCLUDE=//')
 PYTHIA8_INCLUDE=$(scram tool info pythia8 | grep "INCLUDE=" | sed 's/INCLUDE=//')
+GEANT4_BASE=$(scram tool info geant4core | grep "GEANT4CORE_BASE=" | sed 's/GEANT4CORE_BASE=//')
 
 mkdir build
 cd build
-cmake ../ $DEBUGFLAG -DCMAKE_INSTALL_PREFIX=$INSTALLDIR -DVecCore_DIR=$LOCAL/veccore/install/share/VecCore/cmake/ -DUSE_VECGEOM_NAVIGATOR=ON -DVecGeom_DIR=$LOCAL/vecgeom/install/lib/cmake/VecGeom/ -DVecMath_DIR=$LOCAL/vecmath/install/lib/cmake/VecMath/ -DCMAKE_CXX_FLAGS="-O2 -std=c++14" -DUSE_ROOT=ON -DCMAKE_PREFIX_PATH=$LOCAL/veccore/install/lib/cmake/Vc -DHepMC_DIR=$LOCAL/hepmc/install/share/HepMC/cmake/ -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCLHEP_INCLUDE_DIR=${CLHEP_INCLUDE} -DCLHEP_LIBRARY=${CLHEP_LIBDIR}/libCLHEP.so -DPYTHIA8_ROOT_DIR=${PYTHIA8_INCLUDE} -DUSE_TBB=OFF -DWITH_GEANT4=OFF -DDATA_DOWNLOAD=ON
+cmake ../ $DEBUGFLAG -DCMAKE_INSTALL_PREFIX=$INSTALLDIR -DVecCore_DIR=$LOCAL/veccore/install/share/VecCore/cmake/ -DUSE_VECGEOM_NAVIGATOR=ON -DVecGeom_DIR=$LOCAL/vecgeom/install/lib/cmake/VecGeom/ -DVecMath_DIR=$LOCAL/vecmath/install/lib/cmake/VecMath/ -DCMAKE_CXX_FLAGS="-O2 -std=c++14" -DUSE_ROOT=ON -DCMAKE_PREFIX_PATH=$LOCAL/veccore/install/lib/cmake/Vc -DHepMC_DIR=$LOCAL/hepmc/install/share/HepMC/cmake/ -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCLHEP_INCLUDE_DIR=${CLHEP_INCLUDE} -DCLHEP_LIBRARY=${CLHEP_LIBDIR}/libCLHEP.so -DPYTHIA8_ROOT_DIR=${PYTHIA8_INCLUDE} -DUSE_TBB=OFF -DWITH_GEANT4=ON -DGeant4_DIR=${GEANT4_BASE}/lib/Geant4-10.4.0 -DOldVc_INCLUDE_DIR=$LOCAL/oldvc/install/include -DBUILD_REAL_PHYSICS_TESTS=ON -DDATA_DOWNLOAD=ON
 make -j $1
 make install
 

--- a/scripts/install_oldvc.sh
+++ b/scripts/install_oldvc.sh
@@ -25,8 +25,11 @@ else
 	cd $SOURCEDIR
 fi
 
-# just copy header files that are missing from CMSSW
-cp -r include $INSTALLDIR
-for i in avx common mic scalar sse traits; do
-	cp -r $i $INSTALLDIR/include/Vc
-done
+if [ -d build ]; then
+	rm -rf build
+fi
+mkdir build
+cd build
+cmake ../ $DEBUGFLAG -DCMAKE_INSTALL_PREFIX=$INSTALLDIR -DBUILD_TESTING=OFF
+make -j $1
+make install

--- a/scripts/install_oldvc.sh
+++ b/scripts/install_oldvc.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+source init.sh
+
+SOURCEDIR=Vc
+INSTALLDIR=$LOCAL/oldvc/install
+
+if [ -d $INSTALLDIR ]; then
+    rm -rf $INSTALLDIR
+fi
+mkdir -p $INSTALLDIR
+
+if [ "$FORCERECOMP" = "true" ]; then
+	rm -rf $SOURCEDIR
+fi
+
+if ! [ -d $SOURCEDIR ]; then
+	git clone https://github.com/VcDevel/Vc -b 1.2.0
+	cd $SOURCEDIR
+
+	# apply patch for gcc6 incompatibility
+	wget https://github.com/VcDevel/Vc/commit/7b27d13a395c4acb460c7e81fc20ae01a8c763cf.patch
+	git apply 7b27d13a395c4acb460c7e81fc20ae01a8c763cf.patch
+else
+	cd $SOURCEDIR
+fi
+
+# just copy header files that are missing from CMSSW
+cp -r include $INSTALLDIR
+for i in avx common mic scalar sse traits; do
+	cp -r $i $INSTALLDIR/include/Vc
+done

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,7 @@ hepmc \
 veccore \
 vecmath \
 vecgeom \
+oldvc \
 geantv \
 )
 


### PR DESCRIPTION
This PR modifies the GeantV installation to enable its builtin Geant4 standalone tests, compiled against the CMSSW Geant4 version.

This requires:
* reinstalling an old version of Vc, because CMSSW does not distribute either the headers or the libraries (at least in 10_2_X) for this dependency
* hacking the CMake files to avoid compiling the Geant4 examples against the vectorized libraries used in GeantV.